### PR TITLE
Fix hash recording function

### DIFF
--- a/.idea/indexLayout.xml
+++ b/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,40 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="PyPackageRequirementsInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoredPackages">
+        <value>
+          <list size="17">
+            <item index="0" class="java.lang.String" itemvalue="absl-py" />
+            <item index="1" class="java.lang.String" itemvalue="protobuf" />
+            <item index="2" class="java.lang.String" itemvalue="rsa" />
+            <item index="3" class="java.lang.String" itemvalue="google-auth-oauthlib" />
+            <item index="4" class="java.lang.String" itemvalue="Werkzeug" />
+            <item index="5" class="java.lang.String" itemvalue="numpy" />
+            <item index="6" class="java.lang.String" itemvalue="requests" />
+            <item index="7" class="java.lang.String" itemvalue="requests-oauthlib" />
+            <item index="8" class="java.lang.String" itemvalue="tensorboard" />
+            <item index="9" class="java.lang.String" itemvalue="tensorboard-plugin-wit" />
+            <item index="10" class="java.lang.String" itemvalue="certifi" />
+            <item index="11" class="java.lang.String" itemvalue="oauthlib" />
+            <item index="12" class="java.lang.String" itemvalue="cachetools" />
+            <item index="13" class="java.lang.String" itemvalue="urllib3" />
+            <item index="14" class="java.lang.String" itemvalue="Markdown" />
+            <item index="15" class="java.lang.String" itemvalue="google-auth" />
+            <item index="16" class="java.lang.String" itemvalue="idna" />
+          </list>
+        </value>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="SpellCheckingInspection" enabled="true" level="TYPO" enabled_by_default="true">
+      <scope name=".lock files" level="INFORMATION" enabled="true" editorAttributes="INFORMATION_ATTRIBUTES">
+        <option name="processCode" value="true" />
+        <option name="processLiterals" value="true" />
+        <option name="processComments" value="true" />
+      </scope>
+      <option name="processCode" value="true" />
+      <option name="processLiterals" value="true" />
+      <option name="processComments" value="true" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/projectSettingsUpdater.xml
+++ b/.idea/projectSettingsUpdater.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RiderProjectSettingsUpdater">
+    <option name="vcsConfiguration" value="3" />
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/Editor/Generator/KeyGenerator.cs
+++ b/Editor/Generator/KeyGenerator.cs
@@ -68,7 +68,7 @@ namespace Clpsplug.I18n.Editor.Generator
             sb.AppendLine(
                 $"{Indent(indentCount)}/// <summary>"
             );
-            var type = useStringKey ? "string" : "uint";
+            var type = useStringKey ? "string" : "StringHashKey";
             sb.AppendLine(
                 $"{Indent(indentCount)}/// Members in this class can be supplied into <see cref=\"Clpsplug.I18n.Runtime.I18nString.For({type})\"/> parameter."
             );
@@ -135,7 +135,7 @@ namespace Clpsplug.I18n.Editor.Generator
                         sb.AppendLine(
                             useStringKey
                                 ? $"{Indent(currentIndent)}public const string {saneKey} = \"{parentSoFar}{entry.Key}\";\n"
-                                : $"{Indent(currentIndent)}public const uint {saneKey} = 0x{(parentSoFar + entry.Key).Fnv1aHash():X};"
+                                : $"{Indent(currentIndent)}public const StringHashKey {saneKey} = 0x{(parentSoFar + entry.Key).Fnv1aHash():08X};"
                         );
                     }
 
@@ -173,7 +173,7 @@ namespace Clpsplug.I18n.Editor.Generator
                     sb.AppendLine(
                         useStringKey
                             ? $"{Indent(currentIndent)}public const string {saneKey} = \"{parentSoFar}{entry.Key}\";"
-                            : $"{Indent(currentIndent)}public const uint {saneKey} = 0x{(parentSoFar + entry.Key).Fnv1aHash():X};"
+                            : $"{Indent(currentIndent)}public const StringHashKey {saneKey} = 0x{(parentSoFar + entry.Key).Fnv1aHash():08X};"
                     );
                 }
             }

--- a/Editor/Generator/KeyGenerator.cs
+++ b/Editor/Generator/KeyGenerator.cs
@@ -58,6 +58,7 @@ namespace Clpsplug.I18n.Editor.Generator
             sb.AppendLine("// ReSharper disable InconsistentNaming");
             sb.AppendLine("// ReSharper disable MemberHidesStaticFromOuterClass");
             sb.AppendLine("// ReSharper disable UnusedMember.Global\n"); // \n intentional
+            sb.AppendLine($"using StringHashKey = System.UInt32;\n"); // \n intentional
             var indentCount = 0;
             if (!string.IsNullOrEmpty(_namespace))
             {
@@ -135,7 +136,7 @@ namespace Clpsplug.I18n.Editor.Generator
                         sb.AppendLine(
                             useStringKey
                                 ? $"{Indent(currentIndent)}public const string {saneKey} = \"{parentSoFar}{entry.Key}\";\n"
-                                : $"{Indent(currentIndent)}public const StringHashKey {saneKey} = 0x{(parentSoFar + entry.Key).Fnv1aHash():08X};"
+                                : $"{Indent(currentIndent)}public const StringHashKey {saneKey} = 0x{(parentSoFar + entry.Key).Fnv1aHash():X08};"
                         );
                     }
 
@@ -173,7 +174,7 @@ namespace Clpsplug.I18n.Editor.Generator
                     sb.AppendLine(
                         useStringKey
                             ? $"{Indent(currentIndent)}public const string {saneKey} = \"{parentSoFar}{entry.Key}\";"
-                            : $"{Indent(currentIndent)}public const StringHashKey {saneKey} = 0x{(parentSoFar + entry.Key).Fnv1aHash():08X};"
+                            : $"{Indent(currentIndent)}public const StringHashKey {saneKey} = 0x{(parentSoFar + entry.Key).Fnv1aHash():X08};"
                     );
                 }
             }

--- a/Runtime/I18nStaticLabelBase.cs
+++ b/Runtime/I18nStaticLabelBase.cs
@@ -1,8 +1,11 @@
+using System;
 using TMPro;
 using UnityEngine;
 
 namespace Clpsplug.I18n.Runtime
 {
+    using StringHashKey = UInt32;
+
     public abstract class I18nStaticLabelBase : MonoBehaviour
     {
         [SerializeField]

--- a/Runtime/I18nStaticLabelBase.cs
+++ b/Runtime/I18nStaticLabelBase.cs
@@ -14,7 +14,7 @@ namespace Clpsplug.I18n.Runtime
         ]
         protected string key;
 
-        private uint _hash;
+        private StringHashKey _hash;
 
         protected virtual void Awake()
         {

--- a/Runtime/I18nStrings.cs
+++ b/Runtime/I18nStrings.cs
@@ -9,6 +9,8 @@ using UnityEngine;
 
 namespace Clpsplug.I18n.Runtime
 {
+    using StringHashKey = UInt32;
+
     /// <summary>
     /// Supported language configuration interface
     /// </summary>
@@ -139,7 +141,7 @@ namespace Clpsplug.I18n.Runtime
         /// </summary>
         private readonly string key;
 
-        private readonly uint hash;
+        private readonly StringHashKey hash;
 
         private readonly bool _isSoughtByHash;
 
@@ -159,8 +161,8 @@ namespace Clpsplug.I18n.Runtime
         /// <see cref="I18nString"/> constructor, intentionally hidden
         /// </summary>
         /// <param name="hash">FNV-1a hash of string key</param>
-        /// <seealso cref="I18nString.For(uint)"/>;
-        private I18nString(uint hash)
+        /// <seealso cref="I18nString.For(StringHashKey)"/>;
+        private I18nString(StringHashKey hash)
         {
             key = null;
             this.hash = hash;
@@ -184,7 +186,7 @@ namespace Clpsplug.I18n.Runtime
         /// </summary>
         /// <param name="hash">FNV-1a hash of the string</param>
         /// <returns></returns>
-        public static I18nString For(uint hash)
+        public static I18nString For(StringHashKey hash)
         {
             return new I18nString(hash);
         }
@@ -267,7 +269,7 @@ namespace Clpsplug.I18n.Runtime
         /// <summary>
         /// Hashed version of the localized string. This is to be accessed first.
         /// </summary>
-        private readonly Dictionary<uint, FlatLocalizedStringData> _hashedData;
+        private readonly Dictionary<StringHashKey, FlatLocalizedStringData> _hashedData;
 
         // TODO: Support different string definition names
         public static string Path { get; set; } = "strings";
@@ -323,7 +325,7 @@ namespace Clpsplug.I18n.Runtime
             Path = config.StringSourcePath;
             var parser = new I18nStringParser(Path);
             _data = parser.Parse(SupportedLanguage);
-            _hashedData = new Dictionary<uint, FlatLocalizedStringData>();
+            _hashedData = new Dictionary<StringHashKey, FlatLocalizedStringData>();
             parser.ParseForHashedString(SupportedLanguage, _hashedData);
         }
 
@@ -341,7 +343,7 @@ namespace Clpsplug.I18n.Runtime
         }
 
 
-        public FlatLocalizedStringData GetLocalizedStringData(uint hash)
+        public FlatLocalizedStringData GetLocalizedStringData(StringHashKey hash)
         {
             try
             {
@@ -360,7 +362,7 @@ namespace Clpsplug.I18n.Runtime
         /// <param name="hash">Integer hash of string key. Use <see cref="StringExtension.Fnv1aHash"/>.</param>
         /// <param name="valueDict"></param>
         /// <returns></returns>
-        public string GetStringForCurrentLanguage(uint hash, Dictionary<string, object> valueDict = null)
+        public string GetStringForCurrentLanguage(StringHashKey hash, Dictionary<string, object> valueDict = null)
         {
             try
             {
@@ -573,10 +575,10 @@ namespace Clpsplug.I18n.Runtime
         /// <param name="input"></param>
         /// <returns></returns>
         // ReSharper disable once InconsistentNaming
-        public static uint Fnv1aHash(this string input)
+        public static StringHashKey Fnv1aHash(this string input)
         {
-            const uint fnvPrime = 16777619;
-            const uint offsetBasis = 2166136261;
+            const StringHashKey fnvPrime = 16777619;
+            const StringHashKey offsetBasis = 2166136261;
 
             var hash = offsetBasis;
             foreach (var c in input)

--- a/Runtime/Util.cs
+++ b/Runtime/Util.cs
@@ -133,7 +133,7 @@ namespace Clpsplug.I18n.Runtime
         /// <param name="withSupportedLanguage"></param>
         /// <param name="outDict"></param>
         public void ParseForHashedString(ISupportedLanguage withSupportedLanguage,
-            Dictionary<uint, FlatLocalizedStringData> outDict)
+            Dictionary<StringHashKey, FlatLocalizedStringData> outDict)
         {
             var categoryTextAsset = Resources.Load<TextAsset>(_inputPath);
             if (categoryTextAsset == null)
@@ -233,10 +233,10 @@ namespace Clpsplug.I18n.Runtime
         }
 
         private void RecursiveFindStrings(JObject obj, ISupportedLanguage sl, string rootNamespace,
-            Dictionary<uint, FlatLocalizedStringData> outDict)
+            Dictionary<StringHashKey, FlatLocalizedStringData> outDict)
         {
             string key;
-            uint hashedKey;
+            StringHashKey hashedKey;
             bool excludeNewline;
             if (obj.TryGetValue("key", out var keyToken))
             {

--- a/Runtime/Util.cs
+++ b/Runtime/Util.cs
@@ -12,6 +12,8 @@ using UnityEngine;
 
 namespace Clpsplug.I18n.Runtime
 {
+    using StringHashKey = UInt32;
+
     /// <summary>
     /// Gets the supported language configuration from the config file.
     /// </summary>

--- a/Runtime/Util.cs
+++ b/Runtime/Util.cs
@@ -75,12 +75,6 @@ namespace Clpsplug.I18n.Runtime
         public ISupportedLanguage SupportedLanguage { get; }
     }
 
-    internal enum ParseMode
-    {
-        ByString,
-        ByHash,
-    }
-
     /// <summary>
     /// Parser of the I18n string resource.
     /// Usually is not of much use user-side.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.clpsplug.i18ntools",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "displayName": "ClpsPLUG's Internationalization Tools",
   "description": "Internationalization tools and components used to do i18n stuff for ECP games.",
   "author": {


### PR DESCRIPTION
This PR fixes the following glitch:
* The hash the key class generator generated was not padded with 0 to always be 8 digits.

This PR adds the following:
* Type alias for the `uint`, `StringHash`.
* Version bump to 1.3.1